### PR TITLE
fix inc::Module::Install not found

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 
 name           'Test-utf8';


### PR DESCRIPTION
Perl 5.26 released without `.` in `@INC`, which breaks Module::Install's standard method of use: The `inc/` directory in a distribution. Adding `use lib '.';` to the top of the Makefile.PL fixes this. Refs https://rt.cpan.org/Public/Bug/Display.html?id=120706